### PR TITLE
fix(makefile): guard release target against pre-existing tag + tolerate clean tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,9 +163,10 @@ renovate-validate: deps
 release:
 	@bash -c 'read -p "New tag (current: $(CURRENTTAG)): " newtag && \
 		echo "$$newtag" | grep -qE "^v[0-9]+\.[0-9]+\.[0-9]+$$" || { echo "Error: Tag must match vN.N.N"; exit 1; } && \
+		{ ! git rev-parse -q --verify "refs/tags/$$newtag" >/dev/null 2>&1 || { echo "ERROR: tag $$newtag already exists locally. Pick a new version or delete it: git tag -d $$newtag"; exit 1; }; } && \
+		{ ! git ls-remote --exit-code --tags origin "refs/tags/$$newtag" >/dev/null 2>&1 || { echo "ERROR: tag $$newtag already exists on origin. Pick a new version."; exit 1; }; } && \
 		echo -n "Create and push $$newtag? [y/N] " && read ans && [ "$${ans:-N}" = y ] && \
-		git add -A && \
-		git commit -a -s -m "Cut $$newtag release" && \
+		{ if [ -n "$$(git status --porcelain)" ]; then git add -A && git commit -a -s -m "Cut $$newtag release"; else echo "clean tree — tagging HEAD"; fi; } && \
 		git tag $$newtag && \
 		git push origin $$newtag && \
 		git push && \


### PR DESCRIPTION
The `release` recipe ran `git add -A` + `git commit` **before** `git tag`, with no check that the tag doesn't already exist. Re-running with an existing tag lands the release commit but aborts at `git tag`, leaving a dangling commit and a half-published release. A second trap: the bare `git commit -a` exits non-zero on a clean tree, aborting the release before any tag is created.

**Fix (Safety Check #16):**
1. Add local (`git rev-parse --verify`) + remote (`git ls-remote`) tag pre-existence guards after the semver validation, before the confirm prompt and any mutation.
2. Guard the commit so a clean tree still tags HEAD (this recipe writes no version file) instead of aborting.

Verified: `make -n release` shows the guards + tolerant commit precede `git tag`; the guard errors (exit 1) against a temporary local `v0.0.99` tag before the confirm (temp tag deleted, never pushed); the clean-tree branch continues to `git tag`.