### PR TITLE
fix(docker): pin pnpm 10 via packageManager to unblock image builds

### DIFF
--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -2,6 +2,9 @@ FROM node:24-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a
 
 WORKDIR /app
 
+# corepack reads the pnpm version from package.json's "packageManager" field;
+# the prompt guard lets it provision that version non-interactively.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable pnpm
 
 COPY package.json pnpm-lock.yaml ./
@@ -14,6 +17,9 @@ FROM node:24-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a
 
 WORKDIR /app
 
+# corepack reads the pnpm version from package.json's "packageManager" field;
+# the prompt guard lets it provision that version non-interactively.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable pnpm
 
 COPY package.json pnpm-lock.yaml ./

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "Express Todo REST API",
   "main": "dist/index.js",
+  "packageManager": "pnpm@10.34.3",
   "scripts": {
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",

--- a/src/web/Dockerfile
+++ b/src/web/Dockerfile
@@ -2,6 +2,9 @@ FROM node:24-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a
 
 WORKDIR /app
 
+# corepack reads the pnpm version from package.json's "packageManager" field;
+# the prompt guard lets it provision that version non-interactively.
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable pnpm
 
 COPY package.json pnpm-lock.yaml ./

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "packageManager": "pnpm@10.34.3",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
fix(docker): pin pnpm 10 via packageManager to unblock image builds

The `docker` job (`docker compose build`) failed at the api image's
`pnpm install --frozen-lockfile --prod` with:

  [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @scarf/scarf@1.4.0,
  protobufjs@7.5.4

Root cause is a pnpm version skew, not a supply-chain policy (the
"Verifying lockfile against supply-chain policies" step actually passed):

- CI's non-docker jobs pin `pnpm/action-setup` to `version: 10`, and both
  package.json files use pnpm-10-style config in the `"pnpm"` field
  (api: `onlyBuiltDependencies`; web: `peerDependencyRules`).
- The Dockerfiles used unpinned `corepack enable pnpm`, so corepack pulled
  pnpm 11.9.0. pnpm 11 no longer reads build-approval fields from
  package.json (they moved to `pnpm-workspace.yaml`'s `allowBuilds` map),
  so the api's `onlyBuiltDependencies` was ignored and pnpm 11 fatally
  errored on the un-approved build scripts. (The web build only survived
  because ignored `peerDependencyRules` is non-fatal, unlike ignored
  build scripts.)

Fix: pin a single pnpm-version source of truth by adding
`"packageManager": "pnpm@10.34.3"` (current latest 10.x) to both
package.json files, so corepack in the Docker builds resolves the same
pnpm 10 as CI — restoring the intended reading of the existing `"pnpm"`
config without migrating its format. Added
`ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0` to the Dockerfile build stages so
corepack provisions the pinned version non-interactively.

Verified locally: `docker build` of both src/api and src/web succeeds
(`Done ... using pnpm v10.34.3`, no ERR_PNPM_IGNORED_BUILDS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)